### PR TITLE
Fixed the last line address detection.

### DIFF
--- a/src/hex_view.rs
+++ b/src/hex_view.rs
@@ -145,17 +145,19 @@ impl HexView {
         if self.pos_locked {
             return;
         }
-        self.cur_pos = val.clamp(0, self.file.data.len() - self.bytes_per_row);
+        let last_line_start_address =
+            (self.file.data.len() / self.bytes_per_row) * self.bytes_per_row;
+        self.cur_pos = val.clamp(0, last_line_start_address);
     }
 
     pub fn adjust_cur_pos(&mut self, delta: isize) {
         if self.pos_locked {
             return;
         }
-        self.cur_pos = (self.cur_pos as isize + delta).clamp(
-            0,
-            self.file.data.len() as isize - self.bytes_per_row as isize,
-        ) as usize;
+        let last_line_start_address =
+            (self.file.data.len() / self.bytes_per_row) * self.bytes_per_row;
+        self.cur_pos =
+            (self.cur_pos as isize + delta).clamp(0, last_line_start_address as isize) as usize;
     }
 
     pub fn bytes_per_screen(&self) -> usize {


### PR DESCRIPTION
There was an issue when you'd scroll to the bottom of the binary file and the bytes weren't aligned, it would align the bytes to the end of the hex view.

Before fix:
![image](https://github.com/ethteck/bdiff/assets/9406770/e7499548-bed0-4b18-9dc7-3b9f7639c6d6)
When scrolling to the end, this occurred:
![image](https://github.com/ethteck/bdiff/assets/9406770/d6dbb313-634c-4c4c-b617-b46ff55bc056)

After fix:
![image](https://github.com/ethteck/bdiff/assets/9406770/ab4f4588-4e8c-4a5f-a8ed-17c58bc73151)
