### PR TITLE
Settings menu

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,6 +431,7 @@ version = "0.7.0"
 dependencies = [
  "anyhow",
  "argh",
+ "dirs",
  "dtoa",
  "eframe",
  "egui-modal",
@@ -813,6 +814,27 @@ checksum = "339ee130d97a610ea5a5872d2bbb130fdf68884ff09d3028b81bec8a1ac23bbc"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1993,6 +2015,12 @@ name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orbclient"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ build = "build.rs"
 [dependencies]
 anyhow = "1.0.75"
 argh = "0.1.12"
+dirs = "5.0.1"
 dtoa = "1.0.9"
 eframe = { version = "0.23.0", features = ["persistence"] }
 egui-modal = "0.2.5"

--- a/src/app.rs
+++ b/src/app.rs
@@ -702,7 +702,10 @@ impl BdiffApp {
     fn overwrite_modal(&mut self, modal: &Modal) {
         modal.show(|ui| {
             modal.title(ui, "Overwrite previous config");
-            ui.label("By saving, you are going to overwrite previous configuration.");
+            ui.label(&format!(
+                "By saving, you are going to overwrite existing configuration file at \"{}\".",
+                "./bdiff.json"
+            ));
             ui.label("Are you sure you want to proceed?");
 
             modal.buttons(ui, |ui| {

--- a/src/app.rs
+++ b/src/app.rs
@@ -252,8 +252,33 @@ impl BdiffApp {
 
                 egui::CollapsingHeader::new("Theme settings").show(ui, |ui| {
                     egui::Frame::group(&Style::default()).show(ui, |ui| {
+                        egui::Grid::new("offset_colors").show(ui, |ui| {
+                            ui.heading("Offset colors");
+                            ui.end_row();
+
+                            ui.label("Offset text color");
+                            ui.color_edit_button_srgba_premultiplied(
+                                self.settings
+                                    .theme_settings
+                                    .offset_text_color
+                                    .as_bytes_mut(),
+                            );
+                            ui.end_row();
+
+                            ui.label("Leading zero color");
+                            ui.color_edit_button_srgba_premultiplied(
+                                self.settings
+                                    .theme_settings
+                                    .offset_leading_zero_color
+                                    .as_bytes_mut(),
+                            );
+                            ui.end_row();
+                        });
+                    });
+
+                    egui::Frame::group(&Style::default()).show(ui, |ui| {
                         egui::Grid::new("hex_view_colors").show(ui, |ui| {
-                            ui.heading("HexView colors");
+                            ui.heading("Hex area colors");
                             ui.end_row();
 
                             ui.label("Selection color");
@@ -284,7 +309,7 @@ impl BdiffApp {
 
                     egui::Frame::group(&Style::default()).show(ui, |ui| {
                         egui::Grid::new("ascii_view_colors").show(ui, |ui| {
-                            ui.heading("AsciiView colors");
+                            ui.heading("Ascii area colors");
                             ui.end_row();
 
                             ui.label("Null color");

--- a/src/app.rs
+++ b/src/app.rs
@@ -100,9 +100,7 @@ impl BdiffApp {
         } else if config_path.exists() {
             read_json_config(config_path).unwrap()
         } else {
-            let conf = Config::default();
-            write_json_config(config_path, &conf).expect("Failed to write empty project config");
-            conf
+            Config::default()
         };
 
         for file in config.files.iter() {

--- a/src/app.rs
+++ b/src/app.rs
@@ -468,11 +468,6 @@ impl eframe::App for BdiffApp {
 
         let goto_modal: Modal = Modal::new(ctx, "goto_modal");
 
-        // Standard HexView input
-        if !goto_modal.is_open() {
-            self.handle_hex_view_input(ctx);
-        }
-
         // Goto modal
         goto_modal.show(|ui| {
             self.show_goto_modal(&goto_modal, ui, ctx);
@@ -486,7 +481,7 @@ impl eframe::App for BdiffApp {
         }
 
         // Standard HexView input
-        if !overwrite_modal.is_open() {
+        if !(overwrite_modal.is_open() || goto_modal.is_open()) {
             self.handle_hex_view_input(ctx);
         }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -5,7 +5,7 @@ use std::{
 
 use anyhow::Error;
 use eframe::{
-    egui::{self, Checkbox},
+    egui::{self, Checkbox, Style},
     epaint::{Rounding, Shadow},
 };
 use egui_modal::Modal;
@@ -231,25 +231,86 @@ impl BdiffApp {
     }
 
     fn show_settings(&mut self, ctx: &egui::Context) {
-        egui::Window::new("Settings").show(ctx, |ui| {
-            egui::ComboBox::from_label("Byte grouping")
-                .selected_text(self.settings.byte_grouping.to_string())
-                .show_ui(ui, |ui| {
-                    let mut add_value = |value: ByteGrouping| {
-                        ui.selectable_value(
-                            &mut self.settings.byte_grouping,
-                            value,
-                            value.to_string(),
-                        );
-                    };
-                    add_value(ByteGrouping::One);
-                    add_value(ByteGrouping::Two);
-                    add_value(ByteGrouping::Four);
-                    add_value(ByteGrouping::Eight);
-                    add_value(ByteGrouping::Sixteen);
-                    add_value(ByteGrouping::ThirtyTwo);
+        egui::Window::new("Settings")
+            .default_open(true)
+            .show(ctx, |ui| {
+                // Byte Grouping
+                ui.horizontal(|ui| {
+                    ui.label("Byte grouping");
+                    egui::ComboBox::from_id_source("byte_grouping_dropdown")
+                        .selected_text(self.settings.byte_grouping.to_string())
+                        .show_ui(ui, |ui| {
+                            for value in ByteGrouping::get_all_options() {
+                                ui.selectable_value(
+                                    &mut self.settings.byte_grouping,
+                                    value,
+                                    value.to_string(),
+                                );
+                            }
+                        });
                 });
-        });
+
+                egui::CollapsingHeader::new("Theme settings").show(ui, |ui| {
+                    egui::Frame::group(&Style::default()).show(ui, |ui| {
+                        egui::Grid::new("hex_view_colors").show(ui, |ui| {
+                            ui.heading("HexView colors");
+                            ui.end_row();
+
+                            ui.label("Selection color");
+                            ui.color_edit_button_srgba_premultiplied(
+                                self.settings.theme_settings.selection_color.as_bytes_mut(),
+                            );
+                            ui.end_row();
+
+                            ui.label("Diff color");
+                            ui.color_edit_button_srgba_premultiplied(
+                                self.settings.theme_settings.diff_color.as_bytes_mut(),
+                            );
+                            ui.end_row();
+
+                            ui.label("Null color");
+                            ui.color_edit_button_srgba_premultiplied(
+                                self.settings.theme_settings.hex_null_color.as_bytes_mut(),
+                            );
+                            ui.end_row();
+
+                            ui.label("Other color");
+                            ui.color_edit_button_srgba_premultiplied(
+                                self.settings.theme_settings.other_hex_color.as_bytes_mut(),
+                            );
+                            ui.end_row();
+                        });
+                    });
+
+                    egui::Frame::group(&Style::default()).show(ui, |ui| {
+                        egui::Grid::new("ascii_view_colors").show(ui, |ui| {
+                            ui.heading("AsciiView colors");
+                            ui.end_row();
+
+                            ui.label("Null color");
+                            ui.color_edit_button_srgba_premultiplied(
+                                self.settings.theme_settings.ascii_null_color.as_bytes_mut(),
+                            );
+                            ui.end_row();
+
+                            ui.label("Ascii color");
+                            ui.color_edit_button_srgba_premultiplied(
+                                self.settings.theme_settings.ascii_color.as_bytes_mut(),
+                            );
+                            ui.end_row();
+
+                            ui.label("Other color");
+                            ui.color_edit_button_srgba_premultiplied(
+                                self.settings
+                                    .theme_settings
+                                    .other_ascii_color
+                                    .as_bytes_mut(),
+                            );
+                            ui.end_row();
+                        });
+                    });
+                })
+            });
     }
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -86,6 +86,7 @@ impl BdiffApp {
                         }
                     }
                 }
+                ret.settings = config.settings;
             }
         }
 

--- a/src/bin_file.rs
+++ b/src/bin_file.rs
@@ -1,7 +1,7 @@
 use std::{
     fs::File,
     io::{BufReader, Read},
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::{atomic::AtomicBool, Arc},
 };
 
@@ -25,8 +25,8 @@ pub struct BinFile {
     pub modified: Arc<AtomicBool>,
 }
 
-pub fn read_file_bytes(path: PathBuf) -> Result<Vec<u8>, Error> {
-    let file = match File::open(path.clone()) {
+pub fn read_file_bytes<P: Into<PathBuf>>(path: P) -> Result<Vec<u8>, Error> {
+    let file = match File::open(path.into()) {
         Ok(file) => file,
         Err(_error) => {
             return Err(Error::msg("Failed to open file"));
@@ -44,8 +44,9 @@ pub fn read_file_bytes(path: PathBuf) -> Result<Vec<u8>, Error> {
 }
 
 impl BinFile {
-    pub fn from_path(path: PathBuf) -> Result<Self, Error> {
-        let data = match read_file_bytes(path.clone()) {
+    pub fn from_path<P: Into<PathBuf>>(path: P) -> Result<Self, Error> {
+        let path: PathBuf = path.into();
+        let data = match read_file_bytes(&path) {
             Ok(data) => data,
             Err(e) => return Err(e),
         };

--- a/src/bin_file.rs
+++ b/src/bin_file.rs
@@ -1,7 +1,7 @@
 use std::{
     fs::File,
     io::{BufReader, Read},
-    path::{Path, PathBuf},
+    path::PathBuf,
     sync::{atomic::AtomicBool, Arc},
 };
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,8 +18,6 @@ pub struct FileConfig {
 #[derive(Clone, Deserialize, Serialize)]
 pub struct Config {
     pub files: Vec<FileConfig>,
-    #[serde(default)]
-    pub settings: Settings,
 }
 
 pub fn read_json_config(config_path: &Path) -> Result<Config, Error> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,23 +1,35 @@
 use std::{
     fs::File,
+    io::Write,
     path::{Path, PathBuf},
 };
 
 use anyhow::{Context, Error};
+use serde::{Deserialize, Serialize};
 
-#[derive(Clone, serde::Deserialize)]
+use crate::settings::Settings;
+
+#[derive(Clone, Deserialize, Serialize)]
 pub struct FileConfig {
     pub path: PathBuf,
     pub map: Option<PathBuf>,
 }
 
-#[derive(Clone, serde::Deserialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct Config {
     pub files: Vec<FileConfig>,
+    #[serde(default)]
+    pub settings: Settings,
 }
 
 pub fn read_json_config(config_path: &Path) -> Result<Config, Error> {
     let mut reader = File::open(config_path)
         .with_context(|| format!("Failed to open config file at {}", config_path.display()))?;
     Ok(serde_json::from_reader(&mut reader)?)
+}
+
+pub fn write_json_config(config_path: &Path, config: &Config) -> Result<(), Error> {
+    let mut writer = File::open(config_path)
+        .with_context(|| format!("Failed to open config file at {}", config_path.display()))?;
+    Ok(writer.write_all(serde_json::to_string_pretty(config)?.as_bytes())?)
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,6 +28,7 @@ pub fn read_json_config(config_path: &Path) -> Result<Config, Error> {
     Ok(serde_json::from_reader(&mut reader)?)
 }
 
+#[allow(dead_code)]
 pub fn write_json_config(config_path: &Path, config: &Config) -> Result<(), Error> {
     let mut writer = File::open(config_path)
         .with_context(|| format!("Failed to open config file at {}", config_path.display()))?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,5 @@
 use std::{
-    fs::File,
+    fs::{File, OpenOptions},
     io::Write,
     path::{Path, PathBuf},
 };
@@ -7,17 +7,30 @@ use std::{
 use anyhow::{Context, Error};
 use serde::{Deserialize, Serialize};
 
-use crate::settings::Settings;
-
 #[derive(Clone, Deserialize, Serialize)]
 pub struct FileConfig {
     pub path: PathBuf,
     pub map: Option<PathBuf>,
 }
 
-#[derive(Clone, Deserialize, Serialize)]
+impl From<PathBuf> for FileConfig {
+    fn from(path: PathBuf) -> Self {
+        Self { path, map: None }
+    }
+}
+
+impl From<&Path> for FileConfig {
+    fn from(path: &Path) -> Self {
+        let path: PathBuf = path.into();
+        Self { path, map: None }
+    }
+}
+
+#[derive(Clone, Deserialize, Serialize, Default)]
 pub struct Config {
     pub files: Vec<FileConfig>,
+    #[serde(skip)]
+    pub changed: bool,
 }
 
 pub fn read_json_config(config_path: &Path) -> Result<Config, Error> {
@@ -27,8 +40,14 @@ pub fn read_json_config(config_path: &Path) -> Result<Config, Error> {
 }
 
 #[allow(dead_code)]
-pub fn write_json_config(config_path: &Path, config: &Config) -> Result<(), Error> {
-    let mut writer = File::open(config_path)
-        .with_context(|| format!("Failed to open config file at {}", config_path.display()))?;
+pub fn write_json_config<P: Into<PathBuf>>(config_path: P, config: &Config) -> Result<(), Error> {
+    let path: PathBuf = config_path.into();
+    let mut oo = OpenOptions::new();
+    let mut writer = oo
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(&path)
+        .with_context(|| format!("Failed to open config file at {}", path.display()))?;
     Ok(writer.write_all(serde_json::to_string_pretty(config)?.as_bytes())?)
 }

--- a/src/data_viewer.rs
+++ b/src/data_viewer.rs
@@ -4,13 +4,13 @@ use crate::bin_file::Endianness;
 
 pub struct DataViewer {
     pub show: bool,
-    pub i8: bool,
+    pub s8: bool,
     pub u8: bool,
-    pub i16: bool,
+    pub s16: bool,
     pub u16: bool,
-    pub i32: bool,
+    pub s32: bool,
     pub u32: bool,
-    pub i64: bool,
+    pub s64: bool,
     pub u64: bool,
     pub f32: bool,
     pub f64: bool,
@@ -20,13 +20,13 @@ impl Default for DataViewer {
     fn default() -> DataViewer {
         DataViewer {
             show: false,
-            i8: true,
+            s8: true,
             u8: true,
-            i16: true,
+            s16: true,
             u16: true,
-            i32: true,
+            s32: true,
             u32: true,
-            i64: false,
+            s64: false,
             u64: false,
             f32: true,
             f64: true,
@@ -58,12 +58,12 @@ fn display_type(
 }
 
 macro_rules! create_display_type {
-    ($ui:expr, $selected_bytes:expr, $endianness:expr, $delimiter:expr, $represented_type:ty, $value:expr, $size:expr) => {
+    ($ui:expr, $selected_bytes:expr, $endianness:expr, $delimiter:expr, $represented_type:ty, $type_name:literal, $value:expr, $size:expr) => {
         display_type(
             $ui,
             $selected_bytes,
             $value,
-            stringify!($represented_type),
+            $type_name,
             $size,
             |chunk| {
                 format!(
@@ -79,12 +79,12 @@ macro_rules! create_display_type {
             $delimiter,
         );
     };
-    ($ui:expr, $selected_bytes:expr, $endianness:expr, $delimiter:expr, $represented_type:ty, $value:expr, $size:expr, $float_buffer:expr) => {
+    ($ui:expr, $selected_bytes:expr, $endianness:expr, $delimiter:expr, $represented_type:ty, $type_name:literal, $value:expr, $size:expr, $float_buffer:expr) => {
         display_type(
             $ui,
             $selected_bytes,
             $value,
-            stringify!($represented_type),
+            $type_name,
             $size,
             |chunk| {
                 $float_buffer
@@ -123,13 +123,13 @@ impl DataViewer {
                         ));
 
                         ui.menu_button("...", |ui| {
-                            ui.checkbox(&mut self.i8, "i8");
+                            ui.checkbox(&mut self.s8, "s8");
                             ui.checkbox(&mut self.u8, "u8");
-                            ui.checkbox(&mut self.i16, "i16");
+                            ui.checkbox(&mut self.s16, "s16");
                             ui.checkbox(&mut self.u16, "u16");
-                            ui.checkbox(&mut self.i32, "i32");
+                            ui.checkbox(&mut self.s32, "s32");
                             ui.checkbox(&mut self.u32, "u32");
-                            ui.checkbox(&mut self.i64, "i64");
+                            ui.checkbox(&mut self.s64, "s64");
                             ui.checkbox(&mut self.u64, "u64");
                             ui.checkbox(&mut self.f32, "f32");
                             ui.checkbox(&mut self.f64, "f64");
@@ -156,20 +156,93 @@ impl DataViewer {
         let mut float_buffer = dtoa::Buffer::new();
         let delimiter = ", ";
 
-        create_display_type!(ui, &selected_bytes, endianness, delimiter, i8, self.i8, 1);
-        create_display_type!(ui, &selected_bytes, endianness, delimiter, u8, self.u8, 1);
-        create_display_type!(ui, &selected_bytes, endianness, delimiter, i16, self.i16, 2);
-        create_display_type!(ui, &selected_bytes, endianness, delimiter, u16, self.u16, 2);
-        create_display_type!(ui, &selected_bytes, endianness, delimiter, i32, self.i32, 4);
-        create_display_type!(ui, &selected_bytes, endianness, delimiter, u32, self.u32, 4);
-        create_display_type!(ui, &selected_bytes, endianness, delimiter, i64, self.i64, 8);
-        create_display_type!(ui, &selected_bytes, endianness, delimiter, u64, self.u64, 8);
+        create_display_type!(
+            ui,
+            &selected_bytes,
+            endianness,
+            delimiter,
+            i8,
+            "s8",
+            self.s8,
+            1
+        );
+        create_display_type!(
+            ui,
+            &selected_bytes,
+            endianness,
+            delimiter,
+            u8,
+            "u8",
+            self.u8,
+            1
+        );
+        create_display_type!(
+            ui,
+            &selected_bytes,
+            endianness,
+            delimiter,
+            i16,
+            "s16",
+            self.s16,
+            2
+        );
+        create_display_type!(
+            ui,
+            &selected_bytes,
+            endianness,
+            delimiter,
+            u16,
+            "u16",
+            self.u16,
+            2
+        );
+        create_display_type!(
+            ui,
+            &selected_bytes,
+            endianness,
+            delimiter,
+            i32,
+            "s32",
+            self.s32,
+            4
+        );
+        create_display_type!(
+            ui,
+            &selected_bytes,
+            endianness,
+            delimiter,
+            u32,
+            "u32",
+            self.u32,
+            4
+        );
+        create_display_type!(
+            ui,
+            &selected_bytes,
+            endianness,
+            delimiter,
+            i64,
+            "s64",
+            self.s64,
+            8
+        );
+        create_display_type!(
+            ui,
+            &selected_bytes,
+            endianness,
+            delimiter,
+            u64,
+            "u64",
+            self.u64,
+            8
+        );
         create_display_type!(
             ui,
             &selected_bytes,
             endianness,
             delimiter,
             f32,
+            "f32",
             self.f32,
             4,
             float_buffer
@@ -180,6 +253,7 @@ impl DataViewer {
             endianness,
             delimiter,
             f64,
+            "f64",
             self.f64,
             8,
             float_buffer

--- a/src/data_viewer.rs
+++ b/src/data_viewer.rs
@@ -123,13 +123,13 @@ impl DataViewer {
                         ));
 
                         ui.menu_button("...", |ui| {
-                            ui.checkbox(&mut self.i8, "s8");
+                            ui.checkbox(&mut self.i8, "i8");
                             ui.checkbox(&mut self.u8, "u8");
-                            ui.checkbox(&mut self.i16, "s16");
+                            ui.checkbox(&mut self.i16, "i16");
                             ui.checkbox(&mut self.u16, "u16");
-                            ui.checkbox(&mut self.i32, "s32");
+                            ui.checkbox(&mut self.i32, "i32");
                             ui.checkbox(&mut self.u32, "u32");
-                            ui.checkbox(&mut self.i64, "s64");
+                            ui.checkbox(&mut self.i64, "i64");
                             ui.checkbox(&mut self.u64, "u64");
                             ui.checkbox(&mut self.f32, "f32");
                             ui.checkbox(&mut self.f64, "f64");

--- a/src/hex_view.rs
+++ b/src/hex_view.rs
@@ -246,9 +246,15 @@ impl HexView {
                                         .size(font_size)
                                         .color({
                                             if offset_leading_zeros {
-                                                Color32::DARK_GRAY
+                                                Color32::from(
+                                                    theme_settings
+                                                        .offset_leading_zero_color
+                                                        .clone(),
+                                                )
                                             } else {
-                                                Color32::GRAY
+                                                Color32::from(
+                                                    theme_settings.offset_text_color.clone(),
+                                                )
                                             }
                                         }),
                                 );

--- a/src/hex_view.rs
+++ b/src/hex_view.rs
@@ -11,7 +11,7 @@ use crate::{
     data_viewer::DataViewer,
     diff_state::DiffState,
     map_tool::MapTool,
-    settings::Settings,
+    settings::{Settings, ThemeSettings},
     string_viewer::StringViewer,
     widget::spacer::Spacer,
 };
@@ -195,6 +195,7 @@ impl HexView {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn show_hex_grid(
         &mut self,
         diff_state: &DiffState,
@@ -204,6 +205,7 @@ impl HexView {
         can_selection_change: bool,
         font_size: f32,
         byte_grouping: usize,
+        theme_settings: ThemeSettings,
     ) {
         let grid_rect = ui
             .group(|ui| {
@@ -281,24 +283,25 @@ impl HexView {
                                     egui::RichText::new(byte_text)
                                         .monospace()
                                         .size(font_size)
-                                        .color(if diff_state.enabled {
-                                            if diff_state.is_diff_at(row_current_pos) {
-                                                Color32::RED
+                                        .color(
+                                            if diff_state.enabled
+                                                && diff_state.is_diff_at(row_current_pos)
+                                            {
+                                                Color32::from(theme_settings.diff_color.clone())
                                             } else {
                                                 match byte {
-                                                    Some(0) => Color32::DARK_GRAY,
-                                                    _ => Color32::LIGHT_GRAY,
+                                                    Some(0) => Color32::from(
+                                                        theme_settings.hex_null_color.clone(),
+                                                    ),
+                                                    _ => Color32::from(
+                                                        theme_settings.other_hex_color.clone(),
+                                                    ),
                                                 }
-                                            }
-                                        } else {
-                                            match byte {
-                                                Some(0) => Color32::DARK_GRAY,
-                                                _ => Color32::LIGHT_GRAY,
-                                            }
-                                        })
+                                            },
+                                        )
                                         .background_color({
                                             if self.selection.contains(row_current_pos) {
-                                                Color32::DARK_GREEN
+                                                theme_settings.selection_color.clone().into()
                                             } else {
                                                 Color32::TRANSPARENT
                                             }
@@ -351,13 +354,19 @@ impl HexView {
                                         .monospace()
                                         .size(font_size)
                                         .color(match byte {
-                                            Some(0) => Color32::DARK_GRAY,
-                                            Some(32..=126) => Color32::LIGHT_GRAY,
-                                            _ => Color32::GRAY,
+                                            Some(0) => Color32::from(
+                                                theme_settings.ascii_null_color.clone(),
+                                            ),
+                                            Some(32..=126) => {
+                                                Color32::from(theme_settings.ascii_color.clone())
+                                            }
+                                            _ => Color32::from(
+                                                theme_settings.other_ascii_color.clone(),
+                                            ),
                                         })
                                         .background_color({
                                             if self.selection.contains(row_current_pos) {
-                                                Color32::DARK_GREEN
+                                                theme_settings.selection_color.clone().into()
                                             } else {
                                                 Color32::TRANSPARENT
                                             }
@@ -529,6 +538,7 @@ impl HexView {
                                 can_selection_change,
                                 font_size,
                                 settings.byte_grouping.into(),
+                                settings.theme_settings.clone(),
                             );
 
                             if self.show_selection_info {

--- a/src/hex_view.rs
+++ b/src/hex_view.rs
@@ -8,6 +8,7 @@ use crate::{
     app::CursorState,
     bin_file::BinFile,
     bin_file::{read_file_bytes, Endianness},
+    config::Config,
     data_viewer::DataViewer,
     diff_state::DiffState,
     map_tool::MapTool,
@@ -457,6 +458,7 @@ impl HexView {
 
     pub fn show(
         &mut self,
+        config: &mut Config,
         settings: &Settings,
         diff_state: &DiffState,
         ctx: &egui::Context,
@@ -528,6 +530,14 @@ impl HexView {
 
                         if ui.button("X").on_hover_text("Close").clicked() {
                             self.closed = true;
+
+                            // Remove file from the config if it's closed.
+                            if let Some(pos) =
+                                config.files.iter().position(|a| a.path == self.file.path)
+                            {
+                                config.files.remove(pos);
+                                config.changed = true;
+                            }
                         }
                     },
                 );

--- a/src/hex_view.rs
+++ b/src/hex_view.rs
@@ -11,6 +11,7 @@ use crate::{
     data_viewer::DataViewer,
     diff_state::DiffState,
     map_tool::MapTool,
+    settings::Settings,
     string_viewer::StringViewer,
     widget::spacer::Spacer,
 };
@@ -202,6 +203,7 @@ impl HexView {
         cursor_state: CursorState,
         can_selection_change: bool,
         font_size: f32,
+        byte_grouping: usize,
     ) {
         let grid_rect = ui
             .group(|ui| {
@@ -263,7 +265,7 @@ impl HexView {
                             // hex view
                             let mut i = 0;
                             while i < self.bytes_per_row {
-                                if i > 0 && (i % 8) == 0 {
+                                if i > 0 && (i % byte_grouping) == 0 {
                                     ui.add(Spacer::default().spacing_x(4.0));
                                 }
                                 let row_current_pos = current_pos + i;
@@ -440,6 +442,7 @@ impl HexView {
 
     pub fn show(
         &mut self,
+        settings: &Settings,
         diff_state: &DiffState,
         ctx: &egui::Context,
         cursor_state: CursorState,
@@ -525,6 +528,7 @@ impl HexView {
                                 cursor_state,
                                 can_selection_change,
                                 font_size,
+                                settings.byte_grouping.into(),
                             );
 
                             if self.show_selection_info {

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod diff_state;
 mod hex_view;
 mod map_file;
 mod map_tool;
+mod settings;
 mod string_viewer;
 mod watcher;
 mod widget;

--- a/src/map_file.rs
+++ b/src/map_file.rs
@@ -63,7 +63,7 @@ impl MapFile {
     pub fn get_entry(&self, start: usize, end: usize) -> Option<&MapFileEntry> {
         let entries: Vec<_> = self.data.values(start..end).collect();
 
-        match entries.get(0) {
+        match entries.first() {
             Some(entry) => {
                 if entry.symbol_vrom > start {
                     return None;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,6 +1,5 @@
-#[derive(
-    serde::Deserialize, serde::Serialize, Default, PartialEq, Eq, PartialOrd, Ord, Clone, Copy,
-)]
+use serde::{Deserialize, Serialize};
+#[derive(Deserialize, Serialize, Default, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
 pub enum ByteGrouping {
     One,
     Two,
@@ -38,7 +37,7 @@ impl From<ByteGrouping> for usize {
     }
 }
 
-#[derive(serde::Deserialize, serde::Serialize, Default, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Deserialize, Serialize, Default, PartialEq, Eq, PartialOrd, Ord, Clone)]
 pub struct Settings {
     pub byte_grouping: ByteGrouping,
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,4 +1,12 @@
+use eframe::epaint::Color32;
 use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Default, PartialEq, Eq, PartialOrd, Ord, Clone)]
+pub struct Settings {
+    pub byte_grouping: ByteGrouping,
+    pub theme_settings: ThemeSettings,
+}
+
 #[derive(Deserialize, Serialize, Default, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
 pub enum ByteGrouping {
     One,
@@ -7,7 +15,18 @@ pub enum ByteGrouping {
     #[default]
     Eight,
     Sixteen,
-    ThirtyTwo,
+}
+
+impl ByteGrouping {
+    pub fn get_all_options() -> Vec<ByteGrouping> {
+        vec![
+            ByteGrouping::One,
+            ByteGrouping::Two,
+            ByteGrouping::Four,
+            ByteGrouping::Eight,
+            ByteGrouping::Sixteen,
+        ]
+    }
 }
 
 impl ToString for ByteGrouping {
@@ -18,7 +37,6 @@ impl ToString for ByteGrouping {
             Self::Four => "Four",
             Self::Eight => "Eight",
             Self::Sixteen => "Sixteen",
-            Self::ThirtyTwo => "Thirty two",
         }
         .to_string()
     }
@@ -32,12 +50,62 @@ impl From<ByteGrouping> for usize {
             ByteGrouping::Four => 4,
             ByteGrouping::Eight => 8,
             ByteGrouping::Sixteen => 16,
-            ByteGrouping::ThirtyTwo => 32,
         }
     }
 }
 
-#[derive(Deserialize, Serialize, Default, PartialEq, Eq, PartialOrd, Ord, Clone)]
-pub struct Settings {
-    pub byte_grouping: ByteGrouping,
+#[derive(Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord, Clone)]
+pub struct Color(pub [u8; 4]);
+
+impl Color {
+    pub fn as_bytes(&self) -> &[u8; 4] {
+        &self.0
+    }
+
+    pub fn as_bytes_mut(&mut self) -> &mut [u8; 4] {
+        &mut self.0
+    }
+}
+
+impl From<Color32> for Color {
+    fn from(value: Color32) -> Self {
+        Self(value.to_array())
+    }
+}
+
+impl From<Color> for Color32 {
+    fn from(value: Color) -> Self {
+        let sc = value.0;
+        Color32::from_rgba_premultiplied(sc[0], sc[1], sc[2], sc[3])
+    }
+}
+
+#[derive(Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord, Clone)]
+pub struct ThemeSettings {
+    pub selection_color: Color,
+
+    // Hex View colors
+    pub diff_color: Color,
+    pub hex_null_color: Color,
+    pub other_hex_color: Color,
+
+    // ASCII View colors
+    pub ascii_null_color: Color,
+    pub ascii_color: Color,
+    pub other_ascii_color: Color,
+}
+
+impl Default for ThemeSettings {
+    fn default() -> Self {
+        Self {
+            selection_color: Color32::DARK_GREEN.into(),
+            diff_color: Color32::RED.into(),
+            hex_null_color: Color32::DARK_GRAY.into(),
+            other_hex_color: Color32::GRAY.into(),
+
+            ascii_null_color: Color32::DARK_GRAY.into(),
+            ascii_color: Color32::LIGHT_GRAY.into(),
+            other_ascii_color: Color32::GRAY.into(),
+        }
+    }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,0 +1,44 @@
+#[derive(
+    serde::Deserialize, serde::Serialize, Default, PartialEq, Eq, PartialOrd, Ord, Clone, Copy,
+)]
+pub enum ByteGrouping {
+    One,
+    Two,
+    Four,
+    #[default]
+    Eight,
+    Sixteen,
+    ThirtyTwo,
+}
+
+impl ToString for ByteGrouping {
+    fn to_string(&self) -> String {
+        match self {
+            Self::One => "One",
+            Self::Two => "Two",
+            Self::Four => "Four",
+            Self::Eight => "Eight",
+            Self::Sixteen => "Sixteen",
+            Self::ThirtyTwo => "Thirty two",
+        }
+        .to_string()
+    }
+}
+
+impl From<ByteGrouping> for usize {
+    fn from(value: ByteGrouping) -> Self {
+        match value {
+            ByteGrouping::One => 1,
+            ByteGrouping::Two => 2,
+            ByteGrouping::Four => 4,
+            ByteGrouping::Eight => 8,
+            ByteGrouping::Sixteen => 16,
+            ByteGrouping::ThirtyTwo => 32,
+        }
+    }
+}
+
+#[derive(serde::Deserialize, serde::Serialize, Default, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Settings {
+    pub byte_grouping: ByteGrouping,
+}

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -84,6 +84,10 @@ impl From<Color> for Color32 {
 pub struct ThemeSettings {
     pub selection_color: Color,
 
+    // Offset colors
+    pub offset_text_color: Color,
+    pub offset_leading_zero_color: Color,
+
     // Hex View colors
     pub diff_color: Color,
     pub hex_null_color: Color,
@@ -98,6 +102,9 @@ pub struct ThemeSettings {
 impl Default for ThemeSettings {
     fn default() -> Self {
         Self {
+            offset_text_color: Color32::GRAY.into(),
+            offset_leading_zero_color: Color32::DARK_GRAY.into(),
+
             selection_color: Color32::DARK_GREEN.into(),
             diff_color: Color32::RED.into(),
             hex_null_color: Color32::DARK_GRAY.into(),

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -8,8 +8,8 @@ use std::{
 
 use notify::Watcher;
 
-pub fn create_watcher(
-    path: PathBuf,
+pub fn create_watcher<P: Into<PathBuf>>(
+    path: P,
     modified: Arc<AtomicBool>,
 ) -> notify::Result<notify::RecommendedWatcher> {
     let mut watcher =
@@ -22,7 +22,7 @@ pub fn create_watcher(
             Err(e) => println!("watch error: {:?}", e),
         })?;
 
-    watcher.watch(&path, notify::RecursiveMode::NonRecursive)?;
+    watcher.watch(&path.into(), notify::RecursiveMode::NonRecursive)?;
 
     Ok(watcher)
 }


### PR DESCRIPTION
I've added a settings menu window under `Options -> Settings`.

The settings menu currently contains settings for changing the colors of the elements inside of `HexView` and `ASCIIView`, and byte grouping.

`Theme settings` is a `CollapsedHeader`, which hides the settings to not clutter the UI if not needed.

Setting changes are seen immediately.

Screenshots:

![image](https://github.com/ethteck/bdiff/assets/9406770/001e6d35-ab96-4058-a485-fe2ff59aade4)
![image](https://github.com/ethteck/bdiff/assets/9406770/b5c7a790-80fa-45ab-a5cf-f833eb03d76c)

Closes #10 .